### PR TITLE
enable to use global resource

### DIFF
--- a/deploy-concourse.sh
+++ b/deploy-concourse.sh
@@ -5,6 +5,7 @@ bosh deploy -d concourse concourse-deployment/cluster/concourse.yml \
      -o concourse-deployment/cluster/operations/static-web.yml \
      -o concourse-deployment/cluster/operations/basic-auth.yml \
      -o concourse-deployment/cluster/operations/external-postgres.yml \
+     -o concourse-deployment/cluster/operations/enable-global-resources.yml \
      -o ops-files/use-specific-stemcell.yml \
      -o ops-files/concourse-teams.yml \
      -o ops-files/concourse-variables.yml \


### PR DESCRIPTION
docs: [Global Resources \(experimental\) \- Concourse CI](https://concourse-ci.org/global-resources.html)

bosh release property: [enable\_global\_resources](https://bosh.io/jobs/web?source=github.com/concourse/concourse-bosh-release&version=5.0.0#p%3denable_global_resources)

Can you tell me your impression of the global resource?